### PR TITLE
Create install-microsoft-odbc-driver-sql-server-macos.md

### DIFF
--- a/docs/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos.md
+++ b/docs/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos.md
@@ -23,7 +23,7 @@ This article provides commands for installing the ODBC driver from the bash shel
 To install Microsoft ODBC driver 17 for SQL Server on macOS, run the following commands:
 
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
 HOMEBREW_NO_ENV_FILTERING=1 ACCEPT_EULA=Y brew install msodbcsql17 mssql-tools
@@ -41,7 +41,7 @@ The following sections provide instructions for installing previous versions of 
 Use the following commands to install the Microsoft ODBC driver 13.1 for SQL Server on OS X 10.11 (El Capitan) and macOS 10.12 (Sierra):
 
 ```bash
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
 brew update
 brew install msodbcsql@13.1.9.2 mssql-tools@14.0.6.0


### PR DESCRIPTION
Updated links for installing ODBC on MacOS to bash since ruby script is deprecated: Updated to /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"

update applies to ODBC 17 and ODBC 13.1 instructions

documentation link:
https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver15